### PR TITLE
 GA_PostprocessBuild

### DIFF
--- a/GameAnalytics/Editor/GA_PostprocessBuild.cs
+++ b/GameAnalytics/Editor/GA_PostprocessBuild.cs
@@ -1,4 +1,4 @@
-﻿#if !UNITY_4_6 // For getting this to work in Unity 4.6 read the iOS build section on our wiki on github at https://github.com/GameAnalytics/GA-SDK-UNITY/wiki/iOS%20Build
+﻿#if !UNITY_4_6 && UNITY_IOS // For getting this to work in Unity 4.6 read the iOS build section on our wiki on github at https://github.com/GameAnalytics/GA-SDK-UNITY/wiki/iOS%20Build
 
 using UnityEditor.iOS.Xcode;
 using UnityEditor.Callbacks;


### PR DESCRIPTION
On windows, `UnityEditor.iOS` doesn't seem to be there all the time. Added `UNITY_IOS` define for the platform dependent compilation.

In other words, fixing this for windows:
```
Assets/GameAnalytics/Editor/GA_PostprocessBuild.cs(3,19): error CS0234: The type or namespace name `iOS' does not exist in the namespace `UnityEditor'. Are you missing an assembly reference?
```