### PR TITLE
PBXProject.GetUnityTargetName is removed at Unity2019.3

### DIFF
--- a/Unity 5/GameAnalytics/Editor/GA_PostprocessBuild.cs
+++ b/Unity 5/GameAnalytics/Editor/GA_PostprocessBuild.cs
@@ -18,8 +18,12 @@ namespace GameAnalyticsSDK.Editor
 				PBXProject proj = new PBXProject();
 				proj.ReadFromString(File.ReadAllText(projPath));
 
+#if UNITY_2019_3_OR_NEWER
+				string target = proj.GetUnityMainTargetGuid();
+#else
 				string targetName = PBXProject.GetUnityTargetName();
 				string target = proj.TargetGuidByName(targetName);
+#endif
 
 				proj.AddFileToBuild(target, proj.AddFile("usr/lib/libsqlite3.dylib", "Frameworks/libsqlite3.dylib", PBXSourceTree.Sdk));
 				proj.AddFileToBuild(target, proj.AddFile("usr/lib/libz.dylib", "Frameworks/libz.dylib", PBXSourceTree.Sdk));


### PR DESCRIPTION
PBXProject.GetUnityTargetName is removed at Unity2019.3 but it is in-use at GA_PostprocessBuild.cs.
So, I edited to call GetUnityMainTargetGuid instead	of the method when using Unity2019.3 or	newer

Reference of Unity2019.3
PBXProject.GetUnityTargetName
https://docs.unity3d.com/2019.3/Documentation/ScriptReference/iOS.Xcode.PBXProject.GetUnityTargetName.html
PBXProject.GetUnityMainTargetGuid
https://docs.unity3d.com/2019.3/Documentation/ScriptReference/iOS.Xcode.PBXProject.GetUnityMainTargetGuid.html