### PR TITLE
Fix android building warning that "e" was not used.

### DIFF
--- a/Unity 5/GameAnalytics/Plugins/Scripts/Wrapper/GA_AndroidWrapper.cs
+++ b/Unity 5/GameAnalytics/Plugins/Scripts/Wrapper/GA_AndroidWrapper.cs
@@ -99,7 +99,7 @@ namespace GameAnalyticsSDK.Wrapper
                 {
                     GA_IMEI.CallStatic("readImei");
                 }
-                catch(Exception e)
+                catch(Exception)
                 {
                 }
             }


### PR DESCRIPTION
When" Treat Warnings As Errors" result build failed.