### PR TITLE
PlayerSettings.SetScriptingDefineSymbolsForGroup should not be called if no change needed

### DIFF
--- a/Unity 5 and higher/GameAnalytics/Editor/GA_PostprocessBuild.cs
+++ b/Unity 5 and higher/GameAnalytics/Editor/GA_PostprocessBuild.cs
@@ -43,16 +43,20 @@ namespace GameAnalyticsSDK.Editor
             foreach (var group in groups)
             {
                 var defines = new List<string>(PlayerSettings.GetScriptingDefineSymbolsForGroup(group).Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries));
-
+                var edited = false;
                 if (enabled && !defines.Contains(entry))
                 {
                     defines.Add(entry);
+                    edited = true;
                 }
                 else if (!enabled && defines.Contains(entry))
                 {
                     defines.Remove(entry);
+                    edited = true;
                 }
-                PlayerSettings.SetScriptingDefineSymbolsForGroup(group, string.Join(";", defines.ToArray()));
+                if (edited) {
+                    PlayerSettings.SetScriptingDefineSymbolsForGroup(group, string.Join(";", defines.ToArray()));
+                }
             }
         }
 


### PR DESCRIPTION
Calling PlayerSettings.SetScriptingDefineSymbolsForGroup creates an unnecessary diff in git repositories. This commit will prevent that unnecessary diff.