### PR TITLE
Fix deprecation warnings in Unity 2020.2

### DIFF
--- a/Unity 5 and higher/GameAnalytics/Editor/GA_SettingsInspector.cs
+++ b/Unity 5 and higher/GameAnalytics/Editor/GA_SettingsInspector.cs
@@ -893,8 +893,6 @@ namespace GameAnalyticsSDK.Editor
 
                                     EditorGUILayout.Space();
                                     break;
-                                default:
-                                    break;
                             }
 
                             if (ga.SelectedPlatformGameID[i] >= 0)
@@ -1629,7 +1627,9 @@ namespace GameAnalyticsSDK.Editor
                     }
                 }
 
-#if UNITY_2018_3_OR_NEWER
+#if UNITY_2020_1_OR_NEWER
+                if (!(www.result == UnityWebRequest.Result.ConnectionError || www.result == UnityWebRequest.Result.ProtocolError))
+#elif UNITY_2018_3_OR_NEWER
                 if (!(www.isNetworkError || www.isHttpError))
 #else
                 if (string.IsNullOrEmpty(www.error))
@@ -1751,7 +1751,9 @@ namespace GameAnalyticsSDK.Editor
                     }
                 }
 
-#if UNITY_2018_3_OR_NEWER
+#if UNITY_2020_1_OR_NEWER
+                if (!(www.result == UnityWebRequest.Result.ConnectionError || www.result == UnityWebRequest.Result.ProtocolError))
+#elif UNITY_2018_3_OR_NEWER
                 if (!(www.isNetworkError || www.isHttpError))
 #else
                 if (string.IsNullOrEmpty(www.error))
@@ -1849,7 +1851,9 @@ namespace GameAnalyticsSDK.Editor
                     }
                 }
 
-#if UNITY_2018_3_OR_NEWER
+#if UNITY_2020_1_OR_NEWER
+                if (!(www.result == UnityWebRequest.Result.ConnectionError || www.result == UnityWebRequest.Result.ProtocolError))
+#elif UNITY_2018_3_OR_NEWER
                 if (!(www.isNetworkError || www.isHttpError))
 #else
                 if (string.IsNullOrEmpty(www.error))
@@ -2027,7 +2031,9 @@ namespace GameAnalyticsSDK.Editor
                     }
                 }
 
-#if UNITY_2018_3_OR_NEWER
+#if UNITY_2020_1_OR_NEWER
+                if (!(www.result == UnityWebRequest.Result.ConnectionError || www.result == UnityWebRequest.Result.ProtocolError))
+#elif UNITY_2018_3_OR_NEWER
                 if (!(www.isNetworkError || www.isHttpError))
 #else
                 if (string.IsNullOrEmpty(www.error))
@@ -2180,7 +2186,9 @@ namespace GameAnalyticsSDK.Editor
                     }
                 }
 
-#if UNITY_2018_3_OR_NEWER
+#if UNITY_2020_1_OR_NEWER
+                if (!(www.result == UnityWebRequest.Result.ConnectionError || www.result == UnityWebRequest.Result.ProtocolError))
+#elif UNITY_2018_3_OR_NEWER
                 if (!(www.isNetworkError || www.isHttpError))
 #else
                 if (string.IsNullOrEmpty(www.error))
@@ -2364,7 +2372,9 @@ namespace GameAnalyticsSDK.Editor
 
             try
             {
-#if UNITY_2018_3_OR_NEWER
+#if UNITY_2020_1_OR_NEWER
+                if (!(www.result == UnityWebRequest.Result.ConnectionError || www.result == UnityWebRequest.Result.ProtocolError))
+#elif UNITY_2018_3_OR_NEWER
                 if (!(www.isNetworkError || www.isHttpError))
 #else
                 if (string.IsNullOrEmpty(www.error))
@@ -2414,7 +2424,9 @@ namespace GameAnalyticsSDK.Editor
 
             try
             {
-#if UNITY_2018_3_OR_NEWER
+#if UNITY_2020_1_OR_NEWER
+                if (!(www.result == UnityWebRequest.Result.ConnectionError || www.result == UnityWebRequest.Result.ProtocolError))
+#elif UNITY_2018_3_OR_NEWER
                 if (!(www.isNetworkError || www.isHttpError))
 #else
                 if (string.IsNullOrEmpty(www.error))

--- a/Unity 5 and higher/GameAnalytics/Editor/GA_SignUp.cs
+++ b/Unity 5 and higher/GameAnalytics/Editor/GA_SignUp.cs
@@ -1379,7 +1379,9 @@ namespace GameAnalyticsSDK.Editor
 
             try
             {
-#if UNITY_2018_3_OR_NEWER
+#if UNITY_2020_1_OR_NEWER
+                if (!(www.result == UnityWebRequest.Result.ConnectionError || www.result == UnityWebRequest.Result.ProtocolError))
+#elif UNITY_2018_3_OR_NEWER
                 if (!(www.isNetworkError || www.isHttpError))
 #else
                 if (string.IsNullOrEmpty(www.error))


### PR DESCRIPTION
Unity 2020.1 introduced UnityWebRequest.result. In Unity 2020.2 beta they will be deprecating the old boolean properties like isNetworkError, isHttpError etc. This PR implements the changes recommended by the warning messages with backwards compatibility.

Also included is a fix for an unreachable code warning.