### PR TITLE
Fix using of C# String.Substring

### DIFF
--- a/Runtime/Scripts/Events/GA_Debug.cs
+++ b/Runtime/Scripts/Events/GA_Debug.cs
@@ -57,7 +57,7 @@ namespace GameAnalyticsSDK.Events
 
                 string _message = lString + " " + sTrace;
                 if (_message.Length > 8192) {
-                    _message = _message.Substring (8192);
+                    _message = _message.Substring (0, 8192);
                 }
 
                 SubmitError(_message, type);

--- a/Runtime/Scripts/Events/GA_Debug.cs
+++ b/Runtime/Scripts/Events/GA_Debug.cs
@@ -57,7 +57,7 @@ namespace GameAnalyticsSDK.Events
 
                 string _message = lString + " " + sTrace;
                 if (_message.Length > 8192) {
-                    _message = _message.Substring (0, 8192);
+                    _message = _message.Substring (0, 8191);
                 }
 
                 SubmitError(_message, type);


### PR DESCRIPTION
If you want to truncate a string after 8192 characters, then you need to specify two indices: start and end. The single-index substring variant will return all characters after 8192 characters