### PR TITLE
Add missing #if check on GameAnalytics.cs (fix console compilation)

### DIFF
--- a/Runtime/Scripts/GameAnalytics.cs
+++ b/Runtime/Scripts/GameAnalytics.cs
@@ -108,7 +108,7 @@ namespace GameAnalyticsSDK
 
         void OnApplicationQuit()
         {
-#if (!UNITY_EDITOR && !UNITY_IOS && !UNITY_ANDROID && !UNITY_TVOS && !UNITY_WEBGL && !UNITY_TIZEN && !UNITY_SWITCH && !UNITY_PS4 && !UNITY_XBOXONE)
+#if (!UNITY_EDITOR && !UNITY_IOS && !UNITY_ANDROID && !UNITY_TVOS && !UNITY_WEBGL && !UNITY_TIZEN && !UNITY_SWITCH && !UNITY_PS4 && !UNITY_XBOXONE && !UNITY_GAMECORE && !UNITY_PS5)
 #if (UNITY_WSA)
             onQuit();
 #else


### PR DESCRIPTION
Scripting symbols for PS5 and GDK (xbox) were missing from the #if on line 111, causing the GA sdk to break console compilation.

Right now we have to use a custom fork to avoid breaking compilation for some of the platforms we want to support, but we would like to come back to the main repo, so it would be greatly appreciated if this can be merged and released on a future sdk version.

I can add the changelog.md and increase the package version on this PR too if you want me to. I didn't do it because I assume you handle version increase & tagging when you see it fit.