### PR TITLE
Fixed ad methods working for WebGL

### DIFF
--- a/Runtime/Scripts/Wrapper/GA_WebGLWrapper.cs
+++ b/Runtime/Scripts/Wrapper/GA_WebGLWrapper.cs
@@ -72,6 +72,15 @@ namespace GameAnalyticsSDK.Wrapper
         [DllImport ("__Internal")]
         private static extern void addErrorEvent(int severity, string message, string fields, bool mergeFields);
 
+        [DllImport("__Internal")]
+        private static extern void addAdEventWithDuration(int adAction, int adType, string adSdkName, string adPlacement, long duration, string fields, bool mergeFields);
+
+        [DllImport("__Internal")]
+        private static extern void addAdEventWithReason(int adAction, int adType, string adSdkName, string adPlacement, int noAdReason, string fields, bool mergeFields);
+
+        [DllImport("__Internal")]
+        private static extern void addAdEvent(int adAction, int adType, string adSdkName, string adPlacement, string fields, bool mergeFields);
+        
         [DllImport ("__Internal")]
         private static extern void setEnabledInfoLog(bool enabled);
 

--- a/Runtime/Scripts/Wrapper/GA_Wrapper.cs
+++ b/Runtime/Scripts/Wrapper/GA_Wrapper.cs
@@ -592,7 +592,7 @@ namespace GameAnalyticsSDK.Wrapper
             {
                 addAdEventWithDuration((int)adAction, (int)adType, adSdkName, adPlacement, duration, fieldsAsString, mergeFields);
             }
-#elif UNITY_IOS || UNITY_ANDROID
+#elif UNITY_IOS || UNITY_ANDROID || UNITY_WEBGL
                 addAdEventWithDuration((int)adAction, (int)adType, adSdkName, adPlacement, duration, fieldsAsString, mergeFields);
 #endif
         }
@@ -605,7 +605,7 @@ namespace GameAnalyticsSDK.Wrapper
             {
                 addAdEventWithReason((int)adAction, (int)adType, adSdkName, adPlacement, (int)noAdReason, fieldsAsString, mergeFields);
             }
-#elif UNITY_IOS || UNITY_ANDROID
+#elif UNITY_IOS || UNITY_ANDROID || UNITY_WEBGL
                 addAdEventWithReason((int)adAction, (int)adType, adSdkName, adPlacement, (int)noAdReason, fieldsAsString, mergeFields);
 #endif
         }
@@ -618,7 +618,7 @@ namespace GameAnalyticsSDK.Wrapper
             {
                 addAdEvent((int)adAction, (int)adType, adSdkName, adPlacement, fieldsAsString, mergeFields);
             }
-#elif UNITY_IOS || UNITY_ANDROID
+#elif UNITY_IOS || UNITY_ANDROID || UNITY_WEBGL
                 addAdEvent((int)adAction, (int)adType, adSdkName, adPlacement, fieldsAsString, mergeFields);
 #endif
         }

--- a/Runtime/WebGL/GameAnalyticsUnity.jslib
+++ b/Runtime/WebGL/GameAnalyticsUnity.jslib
@@ -104,6 +104,21 @@ var GameAnalyticsUnity = {
         fieldsString = fieldsString ? fieldsString : "{}";
         gameanalytics.GameAnalytics.addErrorEvent(severity, Pointer_stringify(message), JSON.parse(fieldsString), mergeFields);
     },
+    addAdEventWithDuration: function (adAction, adType, adSdkName, adPlacement, duration, fields, mergeFields) {
+        var fieldsString = Pointer_stringify(fields);
+        fieldsString = fieldsString ? fieldsString : "{}";
+        gameanalytics.GameAnalytics.addAdEventWithDuration(adAction, adType, Pointer_stringify(adSdkName), Pointer_stringify(adPlacement), duration, JSON.parse(fieldsString), mergeFields);
+    },
+    addAdEventWithReason: function (adAction, adType, adSdkName, adPlacement, noAdReason, fields, mergeFields) {
+        var fieldsString = Pointer_stringify(fields);
+        fieldsString = fieldsString ? fieldsString : "{}";
+        gameanalytics.GameAnalytics.addAdEventWithNoAdReason(adAction, adType, Pointer_stringify(adSdkName), Pointer_stringify(adPlacement), noAdReason, JSON.parse(fieldsString), mergeFields);
+    },
+    addAdEvent: function (adAction, adType, adSdkName, adPlacement, fields, mergeFields) {
+        var fieldsString = Pointer_stringify(fields);
+        fieldsString = fieldsString ? fieldsString : "{}";
+        gameanalytics.GameAnalytics.addAdEvent(adAction, adType, Pointer_stringify(adSdkName), Pointer_stringify(adPlacement), JSON.parse(fieldsString), mergeFields);
+    },
     setEnabledInfoLog: function(enabled)
     {
         gameanalytics.GameAnalytics.setEnabledInfoLog(enabled);


### PR DESCRIPTION
Fixed ad events not working on WebGL platform.

They were already implemented in the .jspre file, but were not declared in the .jslib and in the WebGL wrapper.